### PR TITLE
Fix for mouse move events

### DIFF
--- a/app/document/input/mouse.js
+++ b/app/document/input/mouse.js
@@ -49,6 +49,9 @@ class MouseListener extends events.EventEmitter {
         this.button = buttons.NONE;
         this.started = false;
         this.drawing = false;
+        this.x = null;
+        this.y = null;
+        this.half_y = null;
     }
 
     store(x, y, half_y) {


### PR DESCRIPTION
Fixes mouse move events from not triggering when the cursor is moved over the cell that was most recently selected.